### PR TITLE
Check if player can see the lootbag before opening it.

### DIFF
--- a/Plugin/src/main/java/net/seyarada/pandeloot/drops/containers/LootBag.java
+++ b/Plugin/src/main/java/net/seyarada/pandeloot/drops/containers/LootBag.java
@@ -7,6 +7,7 @@ import net.seyarada.pandeloot.drops.ItemDrop;
 import net.seyarada.pandeloot.drops.LootDrop;
 import net.seyarada.pandeloot.flags.FlagPack;
 import net.seyarada.pandeloot.flags.enums.FlagTrigger;
+import net.seyarada.pandeloot.nms.NMSManager;
 import net.seyarada.pandeloot.utils.ItemUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -74,7 +75,8 @@ public final class LootBag extends LootTable {
             }
 
             if(!isLocked) {
-                if(!data.has(Constants.LOOTBAG_KEY, PersistentDataType.STRING))
+                if(!data.has(Constants.LOOTBAG_KEY, PersistentDataType.STRING) ||
+                        NMSManager.isHiddenFor(i.getEntityId(), e.getPlayer().getUniqueId()))
                     continue;
                 id = data.get(Constants.LOOTBAG_KEY, PersistentDataType.STRING);
             }


### PR DESCRIPTION
Players are able to open a lootbag on the floor even if it's not theirs, this fixes that.